### PR TITLE
Fix installer again.

### DIFF
--- a/CBattle/github/installer.py
+++ b/CBattle/github/installer.py
@@ -29,8 +29,8 @@ from discord.ext import commands
 UPDATING = os.path.isdir("ballsdex/packages/cbattle")
 ASSET_PATH = "https://raw.githubusercontent.com/Dotsian/CBattle/refs/heads/main/assets"
 
-bot: commands.Bot
-ctx: commands.Context
+# bot: commands.Bot
+# ctx: commands.Context
 
 
 @dataclass


### PR DESCRIPTION
It turns out that these are intepreted as local vars, which breaks things (dev.py is dark magic but it does not always work as expected).

So this pr just comments that line out since it breaks the installer. My bad.